### PR TITLE
add the query planner and add it to the scenario

### DIFF
--- a/webui/api-server/dtos.py
+++ b/webui/api-server/dtos.py
@@ -9,6 +9,7 @@ from worldender.models.player import Player
 from worldender.models.world_ender import WorldEnder
 from worldender.models.event import Event
 from worldender.models.world import World
+from worldender.planners.query import QueryPlan
 
 
 class Scenario(BaseModel):
@@ -19,6 +20,7 @@ class Scenario(BaseModel):
     last_world_ender: WorldEnder | None
     events: List[Event] = Field(default_factory=list)
     world_enders: List[WorldEnder] = Field(default_factory=list)
+    query_plan: QueryPlan | None
 
 
 class NewScenarioRequest(BaseModel):

--- a/webui/api-server/main.py
+++ b/webui/api-server/main.py
@@ -1,5 +1,6 @@
 import logging
 from dotenv import load_dotenv
+from worldender.planners.query import query_planner
 
 load_dotenv()
 
@@ -59,6 +60,7 @@ async def new_scenario(scenario_init: NewScenarioRequest) -> NewScenarioResponse
         player=Player(name=scenario_init.player_name, city=scenario_init.city),
         last_event=None,
         last_world_ender=None,
+        query_plan=None,
     )
     event = await next_event(
         f"{scenario_init.city},  {scenario_init.scenario}", aclient
@@ -84,6 +86,8 @@ async def choose(scenario_id: str, choice: Choice):
     logger.info(f"Got WorldEnder: {world_ender}")
     scenario.last_world_ender = world_ender
     scenario.world_enders.append(world_ender)
+    plan = query_planner(world_ender.description)
+    scenario.query_plan = plan
     await store_scenario(scenario_id, scenario)
     return scenario
 

--- a/webui/apps/website/lib/dtos.ts
+++ b/webui/apps/website/lib/dtos.ts
@@ -6,6 +6,11 @@
 */
 
 /**
+ * Enumeration representing the types of queries that can be asked to a question answer system.
+ */
+export type QueryType = "SINGLE" | "MERGE_MULTIPLE_RESPONSES";
+
+/**
  * Choice is a possible choice to make in response to an Event
  * This choice will have an impact on the world and how the story progresses
  * It could lead to the world ending sooner, or later
@@ -90,6 +95,39 @@ export interface Outcome {
   description: string;
 }
 export interface Player {}
+/**
+ * Container class representing a tree of questions to ask a question answer system.
+ * and its dependencies. Make sure every question is in the tree, and every question is asked only once.
+ */
+export interface QueryPlan {
+  /**
+   * The original question we are asking
+   */
+  query_graph: Query[];
+}
+/**
+ * Class representing a single question in a question answer subquery.
+ * Can be either a single question or a multi question merge.
+ */
+export interface Query {
+  /**
+   * Unique id of the query
+   */
+  id: number;
+  /**
+   * Question we are asking using a question answer system, if we are asking multiple questions, this question is asked by also providing the answers to the sub questions
+   */
+  question: string;
+  /**
+   * List of sub questions that need to be answered before we can ask the question. Use a subquery when anything may be unknown, and we need to ask multiple questions to get the answer. Dependences must only be other queries.
+   */
+  dependancies?: number[];
+  /**
+   * Type of question we are asking, either a single question or a multi question merge when there are multiple questions
+   */
+  node_type?: QueryType & string;
+  [k: string]: unknown;
+}
 export interface Scenario {
   slug: string;
   world: World;
@@ -98,6 +136,7 @@ export interface Scenario {
   last_world_ender: WorldEnder | null;
   events?: Event[];
   world_enders?: WorldEnder[];
+  query_plan: QueryPlan | null;
 }
 /**
  * World for the WorldEnder.ai game.
@@ -146,4 +185,11 @@ export interface WorldEnder {
    * The percentage chance that any humans will survive the world ending event
    */
   survival_rate: number;
+  /**
+   * Three choices you could take to try and combat the world ending event
+   *
+   * @minItems 3
+   * @maxItems 3
+   */
+  choices: [string, string, string];
 }

--- a/worldender/worldender/config.py
+++ b/worldender/worldender/config.py
@@ -8,6 +8,6 @@ class AppConfig(BaseModel):
 
 
 app_config = AppConfig(
-    llm_model=os.environ.get("LLM_MODEL", "gpt-4-turbo"),
-    llm_temp=float(os.environ.get("LLM_TEMP", 0.2)),
+    llm_model=os.environ.get("LLM_MODEL", "gpt-4o"),
+    llm_temp=float(os.environ.get("LLM_TEMP", 0.85)),
 )

--- a/worldender/worldender/models/world_ender.py
+++ b/worldender/worldender/models/world_ender.py
@@ -1,3 +1,4 @@
+from typing import List
 from pydantic import BaseModel, Field
 
 class WorldEnder(BaseModel):
@@ -10,6 +11,7 @@ class WorldEnder(BaseModel):
     description: str = Field(description="A detailed description of what happened, including the Events and Outcomes involved")
     death_toll: str = Field(description="The total estimated cost of human life as a readable number example: 1bil")
     survival_rate: float = Field(description="The percentage chance that any humans will survive the world ending event", ge=0.0, le=1.0)
+    choices: List[str] = Field(description="Three choices you could take to try and combat the world ending event", min_items=3, max_items=3)
 
     def report(self):
         dct = self.model_dump()

--- a/worldender/worldender/planners/query.py
+++ b/worldender/worldender/planners/query.py
@@ -1,0 +1,71 @@
+import enum
+from typing import List
+from pydantic import Field, BaseModel
+
+
+class QueryType(str, enum.Enum):
+    """Enumeration representing the types of queries that can be asked to a question answer system."""
+
+    SINGLE_QUESTION = "SINGLE"
+    MERGE_MULTIPLE_RESPONSES = "MERGE_MULTIPLE_RESPONSES"
+
+
+class Query(BaseModel):
+    """Class representing a single question in a query plan."""
+
+    id: int = Field(..., description="Unique id of the query")
+    question: str = Field(
+        ...,
+        description="Question asked using a question answering system",
+    )
+    dependencies: List[int] = Field(
+        default_factory=list,
+        description="List of sub questions that need to be answered before asking this question",
+    )
+    node_type: QueryType = Field(
+        default=QueryType.SINGLE_QUESTION,
+        description="Type of question, either a single question or a multi-question merge",
+    )
+
+
+class QueryPlan(BaseModel):
+    """Container class representing a tree of questions to ask a question answering system."""
+
+    query_graph: List[Query] = Field(
+        ..., description="The query graph representing the plan"
+    )
+
+    def _dependencies(self, ids: List[int]) -> List[Query]:
+        """Returns the dependencies of a query given their ids."""
+        return [q for q in self.query_graph if q.id in ids]
+
+import instructor
+from openai import OpenAI
+
+# Apply the patch to the OpenAI client
+# enables response_model keyword
+client = instructor.from_openai(OpenAI())
+
+
+def query_planner(question: str) -> QueryPlan:
+    PLANNING_MODEL = "gpt-4-0613"
+
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a world class query planning algorithm capable ofbreaking apart questions into its dependency queries such that the answers can be used to inform the parent question. Do not answer the questions, simply provide a correct compute graph with good specific questions to ask and relevant dependencies. Before you call the function, think step-by-step to get a better understanding of the problem.",
+        },
+        {
+            "role": "user",
+            "content": f"Consider: {question}\nGenerate the correct query plan.",
+        },
+    ]
+
+    root = client.chat.completions.create(
+        model=PLANNING_MODEL,
+        temperature=0,
+        response_model=QueryPlan,
+        messages=messages,
+        max_tokens=1000,
+    )
+    return root

--- a/worldender/worldender/simulation.py
+++ b/worldender/worldender/simulation.py
@@ -4,6 +4,7 @@ from urllib.request import urlopen
 from bs4 import BeautifulSoup
 import instructor
 import openai
+from worldender.planners.query import QueryPlan, query_planner
 
 from .models.event import Event
 from .models.world_ender import WorldEnder
@@ -57,3 +58,9 @@ async def next_world_ender(query: str, aclient: openai.Client) -> Event:
         ],
         max_retries=3,
     )
+
+async def get_multiple_choice(description: str) -> QueryPlan:
+    """
+    This function calls the OpenAI API to generate the possible actions based on the description of the world ender event.
+    """
+    return query_planner(description, plan=False)


### PR DESCRIPTION
This creates a 'query planner' that will create a list of queries you can make to try and solve the current situation. Some of them are dependent on earlier queries being answered. We can show these paths of inquiry and require the user select them in a correct order. When you select one, we run the query through GPT to get the information.

it looks like this:
```
    "query_plan": {
        "query_graph": [
            {
                "id": 1,
                "question": "When did the waters near Seattle begin witnessing unprecedented aggression from killer whales?",
                "dependencies": [],
                "node_type": "SINGLE"
            },
            {
                "id": 2,
                "question": "What were the initial reactions and measures taken by the residents, tourists, and authorities in Seattle?",
                "dependencies": [
                    1
                ],
                "node_type": "SINGLE"
            },
            {
                "id": 3,
                "question": "What were the speculated causes for the aggressive behavior of the whales?",
                "dependencies": [
                    1
                ],
                "node_type": "SINGLE"
            },
            {
                "id": 4,
                "question": "What was the actual cause of the aggressive behavior in whales?",
                "dependencies": [
                    3
                ],
                "node_type": "SINGLE"
            },
            {
                "id": 5,
                "question": "How did the aggressive behavior of the whales spread beyond Seattle?",
                "dependencies": [
                    1,
                    4
                ],
                "node_type": "SINGLE"
            },
            {
                "id": 6,
                "question": "What were the effects of the marine pathogen on other marine mammals and humans?",
                "dependencies": [
                    4
                ],
                "node_type": "SINGLE"
            },
            {
                "id": 7,
                "question": "What measures were taken by governments to maintain order and control the spread?",
                "dependencies": [
                    6
                ],
                "node_type": "SINGLE"
            },
            {
                "id": 8,
                "question": "What were the impacts on coastal economies and infrastructures due to the spread of the pathogen?",
                "dependencies": [
                    6,
                    7
                ],
                "node_type": "SINGLE"
            },
            {
                "id": 9,
                "question": "How did the infection move inland and what were its effects?",
                "dependencies": [
                    8
                ],
                "node_type": "SINGLE"
            },
            {
                "id": 10,
                "question": "What was the overall impact of the biological catastrophe?",
                "dependencies": [
                    9
                ],
                "node_type": "SINGLE"
            }
        ]
}
```

Was working on a v0 component to display the choices: https://v0.dev/r/sjUpTu6aehz